### PR TITLE
Coby suggested ergonomic fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Clone this repository, then run:
 ```bash
 export SP1_PRIVATE_KEY=<your SP1 private key starting with 0x>
 export TENDERMINT_RPC_URL=<the URL of a Celestia RPC, which must not be a light node. e.g. https://rpc.lunaroasis.net/>
-export LIGHT_NODE_URL=<the URL of a Celestia a light node. Must not be a full node URL.>
+export LIGHT_NODE_URL=<the URL of a Celestia a light node. Must not be a full node URL. If using docker for mac, or docker for windows, host.docker.internal can replace localhost for a node running on host machine>
 export LIGHT_NODE_AUTH_TOKEN=<the light node authentication token>
 export TRUSTED_BLOCK=<the trusted block number, e.g. 1865870>
 export TARGET_BLOCK=<the target block number, e.g. 1865890>

--- a/run_detached.sh
+++ b/run_detached.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+## To run in detached mode, it's recommended to disable the final command in the build script (CMD ["bash", "/start.sh"])
+
+# Change to the directory that this script lives in
+cd $(dirname "$0")
+
+mkdir -p output
+
+# Run the docker image
+docker run \
+    -d -it \
+    --env TENDERMINT_RPC_URL=$TENDERMINT_RPC_URL \
+    --env LIGHT_NODE_URL=$LIGHT_NODE_URL \
+    --env LIGHT_NODE_AUTH_TOKEN=$LIGHT_NODE_AUTH_TOKEN \
+    --env SP1_PRIVATE_KEY=$SP1_PRIVATE_KEY \
+    --env TRUSTED_BLOCK=$TRUSTED_BLOCK \
+    --env TARGET_BLOCK=$TARGET_BLOCK \
+    --env NAMESPACE=$NAMESPACE \
+    --env COMMITMENT=$COMMITMENT \
+    --env COMMITMENT_BLOCK=$COMMITMENT_BLOCK \
+    --mount type=bind,source="$(pwd)"/output,target=/output/ \
+    mina_celestia 

--- a/run_interactive.sh
+++ b/run_interactive.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## To run in detached mode, it's recommended to disable the final command in the build script (CMD ["bash", "/start.sh"])
+## To run in interactive mode, it's recommended to disable the final command in the build script (CMD ["bash", "/start.sh"])
 
 # Change to the directory that this script lives in
 cd $(dirname "$0")
@@ -8,8 +8,8 @@ cd $(dirname "$0")
 mkdir -p output
 
 # Run the docker image
-docker run \
-    -d -it \
+container_id=$(docker run \
+    -itd \
     --env TENDERMINT_RPC_URL=$TENDERMINT_RPC_URL \
     --env LIGHT_NODE_URL=$LIGHT_NODE_URL \
     --env LIGHT_NODE_AUTH_TOKEN=$LIGHT_NODE_AUTH_TOKEN \
@@ -20,4 +20,9 @@ docker run \
     --env COMMITMENT=$COMMITMENT \
     --env COMMITMENT_BLOCK=$COMMITMENT_BLOCK \
     --mount type=bind,source="$(pwd)"/output,target=/output/ \
-    mina_celestia 
+    mina_celestia)
+
+echo "Container ID: $container_id"
+
+# run the interactive shell
+docker exec -it $container_id /bin/bash

--- a/start.sh
+++ b/start.sh
@@ -48,6 +48,11 @@ rm /o1js-blobstream/scripts/blobstream_example/blobInclusionSP1Proof.json
 cp /blob-stream-inclusion/blobstream/script/proof-with-pis.json /o1js-blobstream/scripts/blobstream_example/blobstreamSP1Proof.json
 cp /blob-stream-inclusion/blob_inclusion/script/proof-with-pis.json /o1js-blobstream/scripts/blobstream_example/blobInclusionSP1Proof.json
 
+echo "Copying the SP1 proofs to output"
+echo
+cp /blob-stream-inclusion/blobstream/script/proof-with-pis.json /output/blobstreamSP1Proof.json
+cp /blob-stream-inclusion/blob_inclusion/script/proof-with-pis.json /output/blobInclusionSP1Proof.json
+
 echo "Running e2e_blobstream_inclusion.sh"
 echo
 export MAX_THREADS=4


### PR DESCRIPTION
Couple of things I noticed while running this.

1. for me, `host.docker.internal` is the correct host name for my celestia light node.  I added a note in the example env to that effect
2. When debugging, running docker in interactive mode and accessing the shell directly to view and edit files, run scripts, etc.. was useful
    - The `start.sh` script ought to work, but using it to start a container takes a very long time, and any progress is lost if the container is not fully built.  This approach makes it easier to run in parts.
3. The SP1 proofs are not written to output, and it would be nice if they were.