### PR TITLE
CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+run-name: ${{ github.actor }} is testing out mina-celestia-docker
+on: [push]
+#on:
+  #push:
+    #branches: [ "main" ]
+  #pull_request:
+    #branches: [ "main" ]
+
+jobs:
+  build_and_run:
+    runs-on: ubuntu-latest
+    steps:
+      #-
+        #name: Print secrets and variables
+        #run: |
+          #echo $LIGHT_NODE_URL
+          #echo $LIGHT_NODE_AUTH_TOKEN
+          #echo $TENDERMINT_RPC_URL
+          #echo $TRUSTED_BLOCK
+          #echo $TARGET_BLOCK
+          #echo $NAMESPACE
+          #echo $COMMITMENT
+          #echo $COMMITMENT_BLOCK
+        #env:
+          #SP1_PRIVATE_KEY: ${{ secrets.SP1_PRIVATE_KEY }}
+          #LIGHT_NODE_URL: ${{ secrets.LIGHT_NODE_URL }}
+          #LIGHT_NODE_AUTH_TOKEN: ${{ secrets.LIGHT_NODE_AUTH_TOKEN }}
+          #TENDERMINT_RPC_URL: ${{ vars.TENDERMINT_RPC_URL }}
+          #TRUSTED_BLOCK: ${{ vars.TRUSTED_BLOCK }}
+          #TARGET_BLOCK: ${{ vars.TARGET_BLOCK }}
+          #NAMESPACE: ${{ vars.NAMESPACE }}
+          #COMMITMENT: ${{ vars.COMMITMENT }}
+          #COMMITMENT_BLOCK: ${{ vars.COMMITMENT_BLOCK }}
+
+      - 
+        name: Checkout code
+        uses: actions/checkout@v4
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      -
+        name: Clear up disk space
+        run: |
+          echo "free space:"
+          df -h
+          bash ./ci_free_disk_space.sh
+          echo "free space:"
+          df -h
+
+      - 
+        name: Clear up disk space #2
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      -
+        name: Build Docker image
+        working-directory: .
+        run: |
+          bash ./build.sh
+
+      -
+        name: Generate proofs
+        working-directory: .
+        run: |
+          bash ./run.sh
+        env:
+          MAX_THREADS: 2
+          SP1_PRIVATE_KEY: ${{ secrets.SP1_PRIVATE_KEY }}
+          LIGHT_NODE_URL: ${{ secrets.LIGHT_NODE_URL }}
+          LIGHT_NODE_AUTH_TOKEN: ${{ secrets.LIGHT_NODE_AUTH_TOKEN }}
+          TENDERMINT_RPC_URL: ${{ vars.TENDERMINT_RPC_URL }}
+          TRUSTED_BLOCK: ${{ vars.TRUSTED_BLOCK }}
+          TARGET_BLOCK: ${{ vars.TARGET_BLOCK }}
+          NAMESPACE: ${{ vars.NAMESPACE }}
+          COMMITMENT: ${{ vars.COMMITMENT }}
+          COMMITMENT_BLOCK: ${{ vars.COMMITMENT_BLOCK }}
+
+      #- 
+        #name: Build Docker Image
+        #if: steps.cache-primes.outputs.cache-hit != 'true'
+        #working-directory: .
+        #run: |
+          #bash ./build.sh
+
+      #-
+        #name: Cache Docker build
+        #id: cache-docker-build
+        #uses: actions/cache@v4
+        #with:
+          #path: docker-build
+          #key: ${{ runner.os }}-docker-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,23 @@ jobs:
           docker-images: true
           swap-storage: true
 
+      #-
+        #name: Build Docker image
+        #working-directory: .
+        #run: |
+          #bash ./build.sh
+
       -
-        name: Build Docker image
+        name: Cache Docker build
+        id: cache-docker-build
+        uses: actions/cache@v4
+        with:
+          path: docker-build
+          key: ${{ runner.os }}-docker-build
+
+      - 
+        name: Build Docker Image
+        if: steps.cache-docker-build.outputs.cache-hit != 'true'
         working-directory: .
         run: |
           bash ./build.sh
@@ -89,18 +104,3 @@ jobs:
           NAMESPACE: ${{ vars.NAMESPACE }}
           COMMITMENT: ${{ vars.COMMITMENT }}
           COMMITMENT_BLOCK: ${{ vars.COMMITMENT_BLOCK }}
-
-      #- 
-        #name: Build Docker Image
-        #if: steps.cache-primes.outputs.cache-hit != 'true'
-        #working-directory: .
-        #run: |
-          #bash ./build.sh
-
-      #-
-        #name: Cache Docker build
-        #id: cache-docker-build
-        #uses: actions/cache@v4
-        #with:
-          #path: docker-build
-          #key: ${{ runner.os }}-docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,13 @@ RUN cd sp1 && \
     git checkout v2.0.0 && \
     cd crates/cli && \
     cargo install --locked --path . && \
+    rm -rf target/release/build && \
+    rm -rf target/release/examples && \
+    rm -rf target/release/deps && \
+    rm -rf target/release/incremental && \
     cd / && \
-    cargo prove install-toolchain
+    cargo prove install-toolchain && \
+    rm -rf /.sp1/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz
 
 # Copy private repos which build.sh should have cloned and compressed
 COPY ./private_repos/o1js-blobstream.tar.gz /
@@ -57,17 +62,27 @@ RUN tar xf /blob-stream-inclusion.tar.gz && \
 
 # Build the proving scripts
 RUN cd /blob-stream-inclusion/blobstream/script && \
-    cargo build --release --features native-gnark --bin prove
+    cargo build --release --features native-gnark --bin prove && \
+    rm -rf target/release/build && \
+    rm -rf target/release/examples && \
+    rm -rf target/release/deps && \
+    rm -rf target/release/incremental
 
 RUN cd /blob-stream-inclusion/blob_inclusion/script && \
-    cargo build --release --features native-gnark --bin prove
+    cargo build --release --features native-gnark --bin prove && \
+    rm -rf target/release/build && \
+    rm -rf target/release/examples && \
+    rm -rf target/release/deps && \
+    rm -rf target/release/incremental
 
 # Download SP1 plonk bn256 artifacts
 RUN mkdir -p /root/.sp1/circuits/v2.0.0 && \
     cd /root/.sp1/circuits/v2.0.0 && \
     wget -q https://sp1-circuits.s3-us-east-2.amazonaws.com/v2.0.0.tar.gz && \
     tar xf v2.0.0.tar.gz && \
-    rm v2.0.0.tar.gz
+    rm v2.0.0.tar.gz && \
+    rm /root/.sp1/circuits/v2.0.0/groth16_pk.bin && \
+    rm /root/.sp1/circuits/v2.0.0/plonk_pk.bin
 
 # For testing only
 #COPY ./bs_sample_proof.json /o1js-blobstream/scripts/blobstream_example/blobstreamSP1Proof.json

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ then
     rm -rf o1js-blobstream
     git clone https://github.com/geometers/o1js-blobstream.git
     cd o1js-blobstream
-    git checkout 2c2ec2b07c13b67e7804dc36c9761018c3976718
+    git checkout 905821de40a44aed1635482aac13e884d43d09e1
     rm -rf .git
     cd ..
     tar -czf $o_src o1js-blobstream

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ b_src="blob-stream-inclusion.tar.gz"
 if [ ! -f $b_src ]
 then
     rm -rf blob-stream-inclusion
-    git clone git@github.com:geometers/blob-stream-inclusion.git
+    git clone https://github.com/geometers/blob-stream-inclusion.git
     cd blob-stream-inclusion
     git checkout 109720c08a9426dc62eb6c76ff757b7655d2feba
     rm -rf .git
@@ -26,7 +26,7 @@ o_src="o1js-blobstream.tar.gz"
 if [ ! -f $o_src ]
 then
     rm -rf o1js-blobstream
-    git clone git@github.com:geometers/o1js-blobstream.git
+    git clone https://github.com/geometers/o1js-blobstream.git
     cd o1js-blobstream
     git checkout 2c2ec2b07c13b67e7804dc36c9761018c3976718
     rm -rf .git

--- a/ci_free_disk_space.sh
+++ b/ci_free_disk_space.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# From https://raw.githubusercontent.com/apache/flink/02d30ace69dc18555a5085eccf70ee884e73a16e/tools/azure-pipelines/free_disk_space.sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The Azure provided machines typically have the following disk allocation:
+# Total space: 85GB
+# Allocated: 67 GB
+# Free: 17 GB
+# This script frees up 28 GB of disk space by deleting unneeded packages and 
+# large directories.
+# The Flink end to end tests download and generate more than 17 GB of files,
+# causing unpredictable behavior and build failures.
+echo "Freeing up disk space on CI system"
+
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+
+df -h
+
+echo "Removing large packages"
+sudo apt-get remove -y '^ghc-8.*'
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y -qq '^llvm-.*'
+sudo apt-get remove -y -qq 'php.*'
+sudo apt-get remove -y -qq 'cpp.*'
+sudo apt-get remove -y -qq 'ruby.*'
+sudo apt-get remove -y -qq 'mysql*'
+sudo apt-get remove -y -qq 'aspnetcore-runtime-*'
+sudo apt-get remove -y -qq humanity-icon-theme monodoc-manual libruby3.0 mono-utils mono-llvm-support gfortran-11 dotnet-targeting-pack-7.0 vim-runtime postgresql-14
+sudo apt-get remove -y -qq azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get autoremove -y
+sudo apt-get clean
+
+echo "Removing /usr/share/dotnet/"
+rm -rf /usr/share/dotnet/


### PR DESCRIPTION
The whole end-to-end CI takes  4h 33m to build the Docker image, generate SP1 proofs, and run o1js-blobstream. It doesn't run the risc0 script, only `e2e_blobstream_inclusion.sh`.

This CI process requires these repository secrets:

- LIGHT_NODE_AUTH_TOKEN
- LIGHT_NODE_URL
- SP1_PRIVATE_KEY

It also requires these repository variables:

- COMMITMENT
- COMMITMENT_BLOCK
- NAMESPACE
- TARGET_BLOCK
- TENDERMINT_RPC_URL
- TRUSTED_BLOCK

Furthermore, even without CI, the changes to `Dockerfile` alone reduce the image size by half.